### PR TITLE
Move to current SPDX license identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "text.min.js",
   "repository": "https://github.com/samthor/fast-text-encoder.git",
   "author": "Sam Thorogood <sam.thorogood@gmail.com>",
-  "license": "Apache-2",
+  "license": "Apache-2.0",
   "devDependencies": {
     "chai": "^4.2.0",
     "mocha": "^7.1.0"


### PR DESCRIPTION
Move to the current SPDX license identifier for Apache-2.0 . Helps tools in identifying license used by the package easily.