### PR TITLE
Fix "decode" compatibility with react-native

### DIFF
--- a/text.js
+++ b/text.js
@@ -143,12 +143,13 @@ function decodeBuffer(bytes) {
  * @return {string}
  */
 function decodeSyncXHR(bytes) {
-  const b = new Blob([bytes], {type: 'text/plain;charset=UTF-8'});
-  const u = URL.createObjectURL(b);
-
+  let u;
   // This hack will fail in non-Edgium Edge because sync XHRs are disabled (and
   // possibly in other places), so ensure there's a fallback call.
   try {
+    const b = new Blob([bytes], {type: 'text/plain;charset=UTF-8'});
+    u = URL.createObjectURL(b);
+    
     const x = new XMLHttpRequest();
     x.open('GET', u, false);
     x.send();
@@ -156,7 +157,7 @@ function decodeSyncXHR(bytes) {
   } catch (e) {
     return decodeFallback(bytes);
   } finally {
-    URL.revokeObjectURL(u);
+    if (u) URL.revokeObjectURL(u);
   }
 }
 


### PR DESCRIPTION
React-Native runtime fails with [Error: Cannot create URL for blob]. Guess Blob differences from it browser api.