### PR TITLE
Add a "ponyfill" version

### DIFF
--- a/build.js
+++ b/build.js
@@ -23,3 +23,20 @@ await import('./text.min.js');
 
 const stat = fs.statSync('text.min.js');
 console.info(`text.min.js: ${stat.size}`);
+
+esbuild.buildSync({
+  entryPoints: ['src/ponyfill.js'],
+  bundle: true,
+  format: 'cjs',
+  platform: 'neutral',
+  sourcemap: 'external',
+  outfile: './package/ponyfill.js',
+  target: 'es5',
+  minify: true,
+});
+
+// confirm it imports
+await import('./package/ponyfill.js');
+
+const ponyfillStat = fs.statSync('ponyfill.js');
+console.info(`ponyfill.js: ${ponyfillStat.size}`);

--- a/src/ponyfill.js
+++ b/src/ponyfill.js
@@ -1,0 +1,2 @@
+export { FastTextEncoder } from './o-encoder.js';
+export { FastTextDecoder } from './o-decoder.js';


### PR DESCRIPTION
Add a ["ponyfill"](https://ponyfill.com/) version that doesn't mutate the global object. So we can use this library without mutating the global environment.

```js
import { FastTextEncoder, FastTextDecoder } from 'fast-text-encoding/ponyfill'
```

The `ponyfill.js` file will be built straightly into `package` folder so no need to copy the file.